### PR TITLE
Game loading and saving

### DIFF
--- a/MechoSoma/RUNTIME/LocalVersion.cpp
+++ b/MechoSoma/RUNTIME/LocalVersion.cpp
@@ -7,10 +7,14 @@
 
 #include "mch_common.h" // For far target
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 /* ----------------------------- STRUCT SECTION ----------------------------- */
 /* ----------------------------- EXTERN SECTION ----------------------------- */
 
-extern char* mchLocalINI;
+extern const char* mchLocalINI;
 
 /* --------------------------- PROTOTYPE SECTION ---------------------------- */
 
@@ -18,12 +22,12 @@ void win32_InitLocale(void);
 void win32_ChangeKeybLayout(void);
 int win32_GetKeybLayoutID(void);
 
-char* getIniKey(char* fname,char* section,char* key);
+const char* getIniKey(const char* fname,const char* section,const char* key);
 
 /* --------------------------- DEFINITION SECTION --------------------------- */
 
-/*
-static int lv_primaryLangID[]
+#ifdef _WIN32
+static int lv_primaryLangID[] = 
 {
 	LANG_AFRIKAANS,		// 0
 	LANG_ALBANIAN,		// 1
@@ -97,27 +101,33 @@ static int lv_primaryLangID[]
 	LANG_UZBEK,		// 69
 	LANG_VIETNAMESE		// 70
 };
+#endif
 
 int lv_curPrimaryLangID = 16;
 
 void win32_InitLocale(void)
 {
+#ifdef _WIN32
 	int lang_id = atoi(getIniKey(mchLocalINI,"language","primary_lang_id"));
-	char* locale_str = getIniKey(mchLocalINI,"language","locale");
+	const char* locale_str = getIniKey(mchLocalINI,"language","locale");
 
 	setlocale(LC_CTYPE,locale_str);
 
 	if(lang_id) 
 		lv_curPrimaryLangID = lang_id;
+#endif
 }
 
 void win32_ChangeKeybLayout(void)
 {
+#ifdef _WIN32
 	ActivateKeyboardLayout((HKL)HKL_NEXT,0);
+#endif
 }
 
 int win32_GetKeybLayoutID(void)
 {
+#ifdef _WIN32
 	int lang_id,primary_lang_id;
 	static char name_str[KL_NAMELENGTH];
 
@@ -132,8 +142,9 @@ int win32_GetKeybLayoutID(void)
 		return 1;
 
 	return 2;
+#endif
+	return 0;
 }
-*/
 
 void lvInit(void)
 {
@@ -144,6 +155,14 @@ void lvInit(void)
 
 unsigned mch_toupper(unsigned ch)
 {
+#ifdef _WIN32
 	return toupper(ch);
+#endif
+	// CP1251 character table
+	if (ch >= 0xE0 && ch <= 0xFF)
+	{
+		return 0xC0 + (ch - 0xE0); 
+	}
+	return ch;
 }
 

--- a/MechoSoma/XTool/filesystem.cpp
+++ b/MechoSoma/XTool/filesystem.cpp
@@ -1,13 +1,13 @@
 #include "filesystem.h"
 
-#include <filesystem>
 #include <algorithm>
+#include <cstring>
 #include <locale>
 #include <stdexcept>
 
-std::string file::normalize_path(const char* input) {
-  namespace fs = std::filesystem;
+namespace fs = std::filesystem;
 
+std::string file::normalize_path(const char* input) {
   const auto current_locale = std::locale();
   auto comparator = [&current_locale](char left, char right) {
     return std::tolower(left, current_locale) == std::tolower(right, current_locale);
@@ -51,4 +51,58 @@ std::string file::normalize_path(const char* input) {
   }
 
   return result_path.string();
+}
+
+using namespace file;
+
+std::optional<fs::path> FileFinder::find_first(const std::string &path) {
+  _path = path;
+  _iterator = fs::directory_iterator(fs::current_path());
+  return find_next();
+}
+
+std::optional<fs::path> FileFinder::find_next() {
+  while (_iterator != std::filesystem::end(_iterator)) {
+    if (_iterator->is_regular_file() && match(_path.c_str(), _iterator->path().filename().string().c_str())) {
+      const auto p = _iterator->path();
+      _iterator++;
+      return p.filename();
+    }
+    _iterator++;
+  }
+  return std::nullopt;
+}
+
+// https://stackoverflow.com/questions/3300419/file-name-matching-with-wildcard
+bool FileFinder::match(char const *needle, char const *haystack) {
+  for (; *needle != '\0'; ++needle) {
+    switch (*needle) {
+    case '?':
+      if (*haystack == '\0') {
+        return false;
+      }
+      ++haystack;
+      break;
+
+    case '*': {
+      if (needle[1] == '\0') {
+        return true;
+      }
+      size_t max = std::strlen(haystack);
+      for (size_t i = 0; i < max; i++) {
+        if (match(needle + 1, haystack + i)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    default:
+      if (*haystack != *needle) {
+        return false;
+      }
+      ++haystack;
+    }
+  }
+  return *haystack == '\0';
 }

--- a/MechoSoma/XTool/filesystem.h
+++ b/MechoSoma/XTool/filesystem.h
@@ -1,10 +1,27 @@
 #pragma once
 
+#include <filesystem>
+#include <optional>
 #include <string>
+#include <vector>
 
 namespace file
 {
 
 std::string normalize_path(const char* input);
+
+class FileFinder
+{
+public:
+    std::optional<std::filesystem::path> find_first(const std::string &path);
+    std::optional<std::filesystem::path> find_next();
+
+private:
+    static bool match(char const *needle, char const *haystack);
+
+private:
+    std::filesystem::path _path;
+    std::filesystem::directory_iterator _iterator;
+};
 
 }

--- a/MechoSoma/XTool/xtool.h
+++ b/MechoSoma/XTool/xtool.h
@@ -35,6 +35,8 @@
 #define XAVI_SYSOBJ_ID		0x03
 #define XD3D_SYSOBJ_ID		0x04
 
+#include <cstdint>
+
 #include "xerrhand.h"
 
 struct XListElement
@@ -255,12 +257,12 @@ struct XBuffer
         XBuffer& operator< (char* v) { return this->operator<((const char*) v); };
 	XBuffer& operator< (char v) { return write(v); }
 	XBuffer& operator< (unsigned char v) { return write(v); }
-	XBuffer& operator< (short v) { return write(v); }
-	XBuffer& operator< (unsigned short v) { return write(v); }
+	XBuffer& operator< (short v) { return write(static_cast<int16_t>(v)); }
+	XBuffer& operator< (unsigned short v) { return write(static_cast<uint16_t>(v)); }
 	XBuffer& operator< (int v ) { return write(v); }
 	XBuffer& operator< (unsigned int v) { return write(v); }
-	XBuffer& operator< (long v) { return write(v); }
-	XBuffer& operator< (unsigned long v) { return write(v); }
+	XBuffer& operator< (long v) { return write(static_cast<int32_t>(v)); }
+	XBuffer& operator< (unsigned long v) { return write(static_cast<uint32_t>(v)); }
 	XBuffer& operator< (float v) { return write(v); }
 	XBuffer& operator< (double v) { return write(v); }
 	XBuffer& operator< (long double v) { return write(v); }
@@ -268,12 +270,12 @@ struct XBuffer
 	XBuffer& operator> (char* v);
 	XBuffer& operator> (char& v) { return read(v); }
 	XBuffer& operator> (unsigned char& v) { return read(v); }
-	XBuffer& operator> (short& v) { return read(v); }
-	XBuffer& operator> (unsigned short& v) { return read(v); }
+	XBuffer& operator> (short& v) { int16_t t = 0; read(t); v = t; return *this; }
+	XBuffer& operator> (unsigned short& v) { uint16_t t = 0; read(t); v = t; return *this; }
 	XBuffer& operator> (int& v) { return read(v); }
 	XBuffer& operator> (unsigned int& v) { return read(v); }
-	XBuffer& operator> (long& v) { return read(v); }
-	XBuffer& operator> (unsigned long& v) { return read(v); }
+	XBuffer& operator> (long& v) { int32_t t = 0; read(t); v = t; return *this; }
+	XBuffer& operator> (unsigned long& v) { uint32_t t = 0; read(t); v = t; return *this; }
 	XBuffer& operator> (float& v) { return read(v); }
 	XBuffer& operator> (double& v) { return read(v); }
 	XBuffer& operator> (long double& v) { return read(v); }

--- a/MechoSoma/XTool/xutil.cpp
+++ b/MechoSoma/XTool/xutil.cpp
@@ -6,6 +6,8 @@
 
 #include <SDL2/SDL.h>
 
+#include "filesystem.h"
+
 static const std::unordered_map<SDL_Keycode, int> keycodeMap{
     { SDLK_UNKNOWN          , VK_UNKNOWN         },
     { SDLK_SPACE            , VK_SPACE           },
@@ -137,6 +139,9 @@ xtList<xtMsgHandlerObject> XSysHandlerLst;
 static bool hXActiveWndEvent = true;
 static bool hXNeedExitEvent = false;
 
+file::FileFinder fileFinder;
+std::string foundFilePath;
+
 XList::XList(void)
 {
 	ClearList();
@@ -203,12 +208,16 @@ void XList::RemoveElement(XListElement* p)
 
 char* XFindFirst(const char* mask)
 {
-	return nullptr;
+	const auto result = fileFinder.find_first(mask);
+	foundFilePath = result ? result->string() : "";
+	return foundFilePath.empty() ? nullptr : foundFilePath.data();
 }
 
 char* XFindNext(void)
 {
-	return nullptr;
+	const auto result = fileFinder.find_next();
+	foundFilePath = result ? result->string() : "";
+	return foundFilePath.empty() ? nullptr : foundFilePath.data();
 }
 
 void xtDeleteFile(const char* fname)
@@ -395,15 +404,6 @@ void mchGraphicsSetup(void)
 std::string win32_get_path_from_regkey(int key_id,const char* subkey_name,const char* value_name)
 {
 	return "";
-}
-
-int win32_GetKeybLayoutID(void)
-{
-    return 0;
-}
-
-void win32_InitLocale(void)
-{
 }
 
 void* win32_load_icon(void)

--- a/MechoSoma/iScreen/savegame.cpp
+++ b/MechoSoma/iScreen/savegame.cpp
@@ -22,19 +22,11 @@
 
 #define DBGCHECK
 
-// TODO: @caiiiycuk implement
-char *_strtime(char *timestr)
-{
-	return nullptr;
-}
-
-// TODO: @caiiiycuk implement
-char *_strdate(char *timestr)
-{
-	return nullptr;
-}
-
 #include "mch_common.h" // For far target
+
+#ifndef _WIN32
+#include <ctime>
+#endif
 
 /* ----------------------------- STRUCT SECTION ----------------------------- */
 
@@ -188,10 +180,18 @@ void acsSaveSlot::save(void)
 	mchRacerStats* p = mch_racerLst.search(0);
 	if(!p) return;
 
+#ifdef _WIN32
 	_strtime(tm);
 	_strdate(dt);
+#endif
 	time_t curTime = timeVal;
 	time(&curTime);
+
+#ifndef _WIN32
+	const auto localTime = std::localtime(&curTime);
+	std::strftime(tm, sizeof(tm), "%T", localTime);
+	std::strftime(dt, sizeof(dt), "%D", localTime);
+#endif
 
 	sprintf(timeString,"%s, %s",tm,dt);
 


### PR DESCRIPTION
close #33 

1. Добавил реализацию FindFirst/FindNext, но только в текущем каталоге. Для игры этого достаточно, потому что поиск save*.dat происходит в текущем каталоге
2. Функция `toupper` не работает на Linux/macOS, потому что игра использует строки в CP1251. В результате при вызове этой функции возвращается тот же символ и не работает 3D шрифт из кубиков. Сделал ручной перевод в верхний регистр
3. `XBuffer` не использовал те же типы для short/long что и `XStream`. Из-за этого падало при загрузке сохраненной игры. Исправил `XBuffer`